### PR TITLE
Documents changes for #71 (Qontract hangs when contract file extension is wrong or contract file is missing)

### DIFF
--- a/documentation/service_virtualisation.md
+++ b/documentation/service_virtualisation.md
@@ -68,7 +68,7 @@ Any request that matches the contract request will be accepted.
 The response will be randomly generated, based on the contract. The contract defines the response as a number, so the response was a randomly generated number. In every run, you will get a different, randomly generated response that matches the contract.
 
 The file extension is `.qontract` by convention, and is enforced by the stub command.
-If you attempt to use a file with a different extension, e.g. _contract_, the command will exit, with a list of files that don't match our criteria.
+When contract files with extensions other than '.qontract' are supplied as input the command will exit and print all the files that have erroneous extensions
 ```shell
 > {{ site.qontract_cmd }} stub random.contract
 The following files do not end with qontract and cannot be used:

--- a/documentation/service_virtualisation.md
+++ b/documentation/service_virtualisation.md
@@ -67,6 +67,14 @@ Any request that matches the contract request will be accepted.
 
 The response will be randomly generated, based on the contract. The contract defines the response as a number, so the response was a randomly generated number. In every run, you will get a different, randomly generated response that matches the contract.
 
+The file extension is `.qontract` by convention, and is enforced by the stub command.
+If you attempt to use a file with a different extension, e.g. _contract_, the command will exit, with a list of files that don't match our criteria.
+```shell
+> {{ site.qontract_cmd }} stub random.contract
+The following files do not end with qontract and cannot be used:
+random.contract
+```
+
 ### Stubbing out specific responses to specific requests
 
 Often, you'll need the stub to return a specific response for a given request.


### PR DESCRIPTION
Documents changes for https://github.com/qontract/qontract/issues/71

Specifies that non-qontract files cause stub to exit