### PR TITLE
Change from `path` to `contractPaths` in getting_started_programmatically.md 

### DIFF
--- a/documentation/getting_started_programmatically.md
+++ b/documentation/getting_started_programmatically.md
@@ -178,7 +178,7 @@ public class PetStoreContractTest extends QontractJUnitSupport {
     @BeforeAll
     public static void setUp() {
         File contract = new File("contract/service.qontract");
-        System.setProperty("path", contract.getAbsolutePath());
+        System.setProperty("contractPaths", contract.getAbsolutePath());
         System.setProperty("host", "localhost");
         System.setProperty("port", "8080");
 


### PR DESCRIPTION
The example is outdated, the 'path' System property is no longer in use and Qontract uses 'contractPaths' System property to tell Qontract where the qontract file lives