### PR TITLE
Fix REQUEST-BODY example reference

### DIFF
--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -299,7 +299,7 @@ Feature: Employees API
     When PUT /znsio/specmatic/employees/10
     Then status 200
     Examples:
-      | id | REQUEST-BODY                                                                             |
+      | id | (REQUEST-BODY)                                                                             |
       | 10 | { "id": 10, "name": "Jill Doe", "department": "Engineering", "designation": "Director" } |
 ```
 


### PR DESCRIPTION
- Use `(REQUEST-BODY)` instead, otherwise the example is ignored.

## Steps to duplicate
1. Follow the instructions and observe the `PUT /znsio/specmatic/employees/10` request body does **not** include any of the example data (e.g. name=`Jill Doe`, etc).
2. Apply this fix.
3. Observe the `PUT /znsio/specmatic/employees/10` request body **does** include the example data.