### PR TITLE
Add information about how to use Docker to run specmatic

### DIFF
--- a/_includes/setup_command_line.md
+++ b/_includes/setup_command_line.md
@@ -17,3 +17,33 @@ java -jar <basedir>/specmatic.jar %*
 ```
 
 The %* portion tells the batch script to pass all of the parameters it receives to the new command.
+
+#### Docker
+
+If you don't want to install Java on your machine, you can also use Docker by creating a file named `Dockerfile` with the following contents:
+
+```Dockerfile
+FROM openjdk:8-jdk-alpine
+
+WORKDIR /specmatic
+
+ADD https://github.com/znsio/specmatic/releases/download/0.72.0/specmatic.jar /specmatic/specmatic.jar
+RUN chmod +x /specmatic/specmatic.jar
+
+WORKDIR /app
+
+ENTRYPOINT ["java", "-jar", "/specmatic/specmatic.jar"]
+```
+
+Before you can run Specmatic in a Docker container, you have to build the image:
+
+```bash
+# Run inside the directory of the above Dockerfile.
+docker build -t specmatic .
+```
+
+Now you can add an alias to conveniently run the `specmatic` command inside a Docker container.
+
+```bash
+alias specmatic='docker run --rm -it -v ${PWD}/:/app -p 9000:9000 specmatic'
+```


### PR DESCRIPTION
There might be people who don't use Java for anything else who don't want to install Java on their machines only to run this tool. By using Docker those people can use Specmatic without having to install Java.