### PR TITLE
code reference link is incorrect

### DIFF
--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -455,7 +455,7 @@ Add the following dependencies to your pom.xml file.
 </dependency>
 ```
 
-Add a class that inherits from SpecmaticJUnitSupport. See how this is done [here](https://github.com/znsio/specmatic-order-api/blob/main/src/test/java/com/store/ContractTests.java).
+Add a class that inherits from SpecmaticJUnitSupport. See how this is done [here](https://github.com/znsio/specmatic-order-api/blob/main/src/test/java/com/store/ContractTest.java).
 
 In it, set the "host" and "port" properties to tell Specmatic where to find the application. You can also start the application in that class.
 


### PR DESCRIPTION
Java example given in https://specmatic.in/documentation/contract_tests.html#the-java-helper-for-java-projects is incorrect, leading to a 404 page.
