### PR TITLE
Use: `soap.json` for consistency with latter usage in the file.

### DIFF
--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -151,7 +151,7 @@ Specmatic returns a contract valid response. The values are randomly generated. 
 
 ## Add A Second Expectation
 
-* Rename the above json file to soap.expectation
+* Rename the above json file to soap.json
 * Create a new json file named batteries.json in the same directory with the following data:
 
 ```json


### PR DESCRIPTION
Fixed mistake where `soap.json` was written as: `soap.expectation`, despite
being referred to as `soap.json` later on in the doc.