### PR TITLE
Documentation Update: Docker Setup For Apple Silicon Machines, Custom Port For Stub Server

### DIFF
--- a/_includes/setup_command_line.md
+++ b/_includes/setup_command_line.md
@@ -38,6 +38,16 @@ Run specmatic by
 docker run znsio/specmatic
 ```
 
+**Important**: If you're using a machine with an Apple Silicon chip, you'll need to enable Rosetta for accelerated x86/amd64 binary emulation.
+
+Please follow these steps to do so:
+
+1. Update your Docker Desktop application to the latest version.
+2. Navigate to 'Settings', then 'General Settings'.
+3. Ensure the `Use Rosetta for x86/amd64 emulation on Apple Silicon` option is checked.
+4. Save your settings and restart Docker Desktop for the changes to take effect.
+
+
 {% endtab %}
 {% endtabs %}
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -292,9 +292,12 @@ npx specmatic stub service.yaml --port 9002
 {% endtab %}
 {% tab stub-custom-port docker %}
 ```shell
+# Note that --port 9002 at the end of the command is crucial. It ensures that the stub 
+# server inside the Docker container is listening on the same port (9002) that's being
+# mapped to port 9000 on your machine. If these ports don't match, you won't be able to
+# access the stub server from your machine.
 docker run -v "/local-directory/service.yaml:/service.yaml" -p 9000:9002 znsio/specmatic stub "/service.yaml" --port 9002
 ```
-**Note:** Ensure that the port you specify matches the one assigned to the container port.
 {% endtab %}
 {% endtabs %}
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -279,18 +279,18 @@ Stub server is running on http://0.0.0.0:9000. Ctrl + C to stop.
 
 **Tip:** You can switch the port number by adding ```--port <port of your choice>``` in the command.
 
-{% tabs stub %}
-{% tab stub java %}
+{% tabs stub-custom-port %}
+{% tab stub-custom-port java %}
 ```shell
 specmatic stub service.yaml --port 9002
 ```
 {% endtab %}
-{% tab stub npm %}
+{% tab stub-custom-port npm %}
 ```shell
 npx specmatic stub service.yaml --port 9002
 ```
 {% endtab %}
-{% tab stub docker %}
+{% tab stub-custom-port docker %}
 ```shell
 docker run -v "/local-directory/service.yaml:/service.yaml" -p 9000:9002 znsio/specmatic stub "/service.yaml" --port 9002
 ```

--- a/getting_started.md
+++ b/getting_started.md
@@ -270,12 +270,33 @@ docker run -v "/local-directory/service.yaml:/service.yaml" -p 9000:9000 znsio/s
 {% endtab %}
 {% endtabs %}
 
-This should start your stub server on port 9000 by default (you can switch the port number by adding ```--port <port of your choice>``` to the above command) as below.
+This should start your stub server on port 9000 by default as below.
 
 ```shell
 Loading service.yaml
 Stub server is running on http://0.0.0.0:9000. Ctrl + C to stop.
 ```
+
+**Tip:** You can switch the port number by adding ```--port <port of your choice>``` in the command.
+
+{% tabs stub %}
+{% tab stub java %}
+```shell
+specmatic stub service.yaml --port 9002
+```
+{% endtab %}
+{% tab stub npm %}
+```shell
+npx specmatic stub service.yaml --port 9002
+```
+{% endtab %}
+{% tab stub docker %}
+```shell
+docker run -v "/local-directory/service.yaml:/service.yaml" -p 9000:9002 znsio/specmatic stub "/service.yaml" --port 9002
+```
+**Note:** Ensure that the port you specify matches the one assigned to the container port.
+{% endtab %}
+{% endtabs %}
 
 Once the stub server is running you can verify the API by accessing it through Postman, Chrome, Curl etc.
 


### PR DESCRIPTION
- **Rosetta Information for Apple Silicon Machines**: Added crucial information for users with Apple Silicon machines. To ensure smooth operation of the Docker Desktop application, users will need to enable Rosetta for accelerated x86/amd64 binary emulation. Detailed steps on how to do this have been included. 
- **Custom Port Usage for Stub Server**: Added instructions on how to use custom ports when running the stub server. This addition will give users more flexibility and control over their setup.

