### PR TITLE
Documentation Update: Programmatically Executing Specmatic Contract As Tests In Python

### DIFF
--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -22,7 +22,7 @@ Contract Tests
     - [Authentication In CI For HTTPS Git Source](#authentication-in-ci-for-https-git-source)
     - [Authentication In CI For SSH Git Source](#authentication-in-ci-for-ssh-git-source)
     - [Examples For WSDL Contracts](#examples-for-wsdl-contracts)
-    - [Programmtically executing Specmatic Contract as Tests](#programmtically-executing-specmatic-contract-as-tests)
+    - [programmatically executing Specmatic Contract as Tests](#programmatically-executing-specmatic-contract-as-tests)
     - [Referring to local specificatons](#referring-to-local-specificatons)
     - [Examples that are not passing yet](#examples-that-are-not-passing-yet)
     - [Examples that trigger 400 responses](#examples-that-trigger-400-responses)
@@ -616,8 +616,10 @@ Feature: WSDL Companion file
 
 (REQUEST-BODY) contains the request body in a single line, SOAPAction contains the value value of the SOAPAction header, and additional columns must be included for each header sent by the SOAP service.
 
-### Programmtically executing Specmatic Contract as Tests
+### programmatically executing Specmatic Contract as Tests
 
+{% tabs programmatically %}
+{% tab programmatically java %}
 If your building your application in a JVM based language, you can run Specmatic Contract Tests programmatically just like any other JUnit test and also get similar feedback within your IDE.
 
 Add Specmatic JUnit Support Jar dependency.
@@ -656,9 +658,74 @@ public class ContractTests extends SpecmaticJUnitSupport {
 
 Here is a complete [Specmatic Contract Test example](https://github.com/znsio/specmatic-order-api/blob/main/src/test/java/com/store/ContractTest.java) for a Springboot application.
 
+{% endtab %}
+{% tab programmatically python %}
+
+1. **Install the Specmatic Python library**: Use pip, a package installer for Python, to install the Specmatic library.
+
+   ```bash
+   pip install specmatic
+   ```
+
+2. **Create a test file**: In your project's test directory, create a new Python file named `test_contract.py`.
+
+3. **Declare a Test Class**: In `test_contract.py`, declare a class named `TestContract`. This class will serve as the container for your contract tests.
+
+   ```python
+   class TestContract:
+      pass
+   ```
+
+4. **Configure and Run Contract Tests**: Use the Specmatic class to configure and run your contract tests. Here's an example of how to do this for a Flask application:
+
+   ```python
+   import os
+   from specmatic import Specmatic
+   from your_project import app, 
+   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+   Specmatic() \
+       .with_project_root(PROJECT_ROOT_DIR) \
+       .with_wsgi_app(app) \
+       .test(TestContract) \
+       .run()
+   ```
+
+   In this example, replace `your_project` with your project's name and `app` with your Flask application object.
+
+5. **Run Tests with a Stub**: If you want to run the tests with a stub, you can do so like this:
+
+   ```python
+   import os
+   from specmatic import Specmatic
+   from your_project import app
+   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+   Specmatic() \
+       .with_project_root(PROJECT_ROOT_DIR) \
+       .with_stub(stub_host, stub_port, [expectation_json_file]) \
+       .with_wsgi_app(app) \
+       .test(TestContract) \
+       .run()
+   ```
+
+   In this example, replace `stub_host`, `stub_port`, and `expectation_json_file` with the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively.
+
+6. **Run the Tests**: You can run the tests from either your IDE or command line by pointing pytest to your test folder:
+
+   ```bash
+   pytest test -v -s
+   ```
+
+   Note: Please ensure that you set the '-v' and '-s' flags while running pytest so that pytest will run all the tests in the test directory and provide detailed output, including any output from the tests themselves.
+
+In this example, replace `app` with your Flask application object.
+{% endtab %}
+{% endtabs %}
+
 ### Referring to local specificatons
 
-If you want to temoporarily refer to API specifications on your local machine please use system property ```contractPaths```.
+If you want to temporarily refer to API specifications on your local machine please use system property ```contractPaths```.
 
 ```java
 @BeforeAll

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -680,38 +680,22 @@ Here is a complete [Specmatic Contract Test example](https://github.com/znsio/sp
 
    ```python
    import os
-   from specmatic import Specmatic
+   from specmatic.core.specmatic import Specmatic
    from your_project import app, 
    PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+   app_host = "127.0.0.1"
+   app_port = 5000
 
    Specmatic() \
        .with_project_root(PROJECT_ROOT_DIR) \
-       .with_wsgi_app(app) \
+       .with_wsgi_app(app, app_host, app_port) \
        .test(TestContract) \
        .run()
    ```
 
    In this example, replace `your_project` with your project's name and `app` with your Flask application object.
 
-5. **Run Tests with a Stub**: If you want to run the tests with a stub, you can do so like this:
-
-   ```python
-   import os
-   from specmatic import Specmatic
-   from your_project import app
-   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-
-   Specmatic() \
-       .with_project_root(PROJECT_ROOT_DIR) \
-       .with_stub(stub_host, stub_port, [expectation_json_file]) \
-       .with_wsgi_app(app) \
-       .test(TestContract) \
-       .run()
-   ```
-
-   In this example, replace `stub_host`, `stub_port`, and `expectation_json_file` with the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively.
-
-6. **Run the Tests**: You can run the tests from either your IDE or command line by pointing pytest to your test folder:
+5. **Run the Tests**: You can run the tests from either your IDE or command line by pointing pytest to your test folder:
 
    ```bash
    pytest test -v -s

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -22,7 +22,7 @@ Contract Tests
     - [Authentication In CI For HTTPS Git Source](#authentication-in-ci-for-https-git-source)
     - [Authentication In CI For SSH Git Source](#authentication-in-ci-for-ssh-git-source)
     - [Examples For WSDL Contracts](#examples-for-wsdl-contracts)
-    - [programmatically executing Specmatic Contract as Tests](#programmatically-executing-specmatic-contract-as-tests)
+    - [Programmatically executing Specmatic Contract as Tests](#programmatically-executing-specmatic-contract-as-tests)
     - [Referring to local specificatons](#referring-to-local-specificatons)
     - [Examples that are not passing yet](#examples-that-are-not-passing-yet)
     - [Examples that trigger 400 responses](#examples-that-trigger-400-responses)
@@ -616,7 +616,7 @@ Feature: WSDL Companion file
 
 (REQUEST-BODY) contains the request body in a single line, SOAPAction contains the value value of the SOAPAction header, and additional columns must be included for each header sent by the SOAP service.
 
-### programmatically executing Specmatic Contract as Tests
+### Programmatically executing Specmatic Contract as Tests
 
 {% tabs programmatically %}
 {% tab programmatically java %}
@@ -693,7 +693,8 @@ Here is a complete [Specmatic Contract Test example](https://github.com/znsio/sp
        .run()
    ```
 
-   In this example, replace `your_project` with your project's name and `app` with your Flask application object.
+   In this example, replace `your_project` with your project's name and `app` with your Flask application object. If
+   app_host and app_port are not specified, the app will be started on a random available port on 127.0.0.1.
 
 5. **Run the Tests**: You can run the tests from either your IDE or command line by pointing pytest to your test folder:
 
@@ -703,7 +704,7 @@ Here is a complete [Specmatic Contract Test example](https://github.com/znsio/sp
 
    Note: Please ensure that you set the '-v' and '-s' flags while running pytest so that pytest will run all the tests in the test directory and provide detailed output, including any output from the tests themselves.
 
-In this example, replace `app` with your Flask application object.
+Here is a complete [Specmatic Contract Test example](https://github.com/znsio/specmatic-order-api-python/blob/main/test/test_contract_with_coverage.py) for a flask application.
 {% endtab %}
 {% endtabs %}
 

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -459,6 +459,8 @@ Note that this currently works only for JSON request and response payloads. Supp
 
 ## Programmatically starting stub server within tests
 
+{% tabs virtualization %}
+{% tab virtualization java %}
 If your tests are written in a JVM based language, you can start and stop the stub server within your tests programmatically.
 
 Add `specmatic-core` jar dependency with scope set to test since this need not be shipped as part of your production deliverable.
@@ -505,11 +507,76 @@ fun tearDown() {
 }
 ```
 
-Here are complete examples of Karate API test that leverages the above technique.
-* [Kotlin](https://github.com/znsio/specmatic-order-ui/blob/683f59f5024e02af88fb54a55f03d819f852bb2e/src/test/kotlin/controllers/APITests.kt)
-* [Java](https://github.com/znsio/specmatic-order-ui/blob/java_component_test/src/test/java/controllers/APITests.java)
+   Here are complete examples of Karate API test that leverages the above technique.
 
-Please note that this is only a utility for the purpose of convenience in Java projects. Other programming languages can simply run the Specmatic standalone executable just as easily. If you do happpen to write a thin wrapper and would like to contribute the same to the project, please refer to our [contribution guidelines](https://github.com/znsio/specmatic/blob/main/CONTRIBUTING.md).
+  1. [Kotlin](https://github.com/znsio/specmatic-order-ui/blob/683f59f5024e02af88fb54a55f03d819f852bb2e/src/test/kotlin/controllers/APITests.kt)
+
+  2. [Java](https://github.com/znsio/specmatic-order-ui/blob/java_component_test/src/test/java/controllers/APITests.java)
+
+   Please note that this is only a utility for the purpose of convenience in Java projects. Other programming languages can simply run the Specmatic standalone executable just as easily. If you do happpen to write a thin wrapper and would like to contribute the same to the project, please refer to our [contribution guidelines](https://github.com/znsio/specmatic/blob/main/CONTRIBUTING.md).
+{% endtab %}
+{% tab virtualization python %}
+If your tests are written in Python, you can start and stop the stub server within your tests programmatically.
+
+1. **Install the Specmatic Python library**: Use pip, a package installer for Python, to install the Specmatic library.
+
+   ```bash
+   pip install specmatic
+   ```
+
+2. **Run Tests with a Stub**: If you want to run the tests with a stub, you can do so like this:
+
+   ```python
+   import os
+   from specmatic.core.specmatic import Specmatic
+   from your_project import app
+   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+   stub_host = "127.0.0.1"
+   stub_port = 5000
+
+   Specmatic() \
+       .with_project_root(PROJECT_ROOT_DIR) \
+       .with_stub(stub_host, stub_port, [expectation_json_file]) \
+       .with_wsgi_app(app) \
+       .test(TestContract) \
+       .run()
+   ```
+
+   In this example, we are passing an instance of wsgi app like flask. `stub_host`, `stub_port`, and `expectation_json_file` are the the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively. Replace `app` with your Flask application object.¸
+{% endtab %}
+{% endtabs %}
+
+<!-- 
+{% tab virtualization python %}
+
+If your tests are written in Python, you can start and stop the stub server within your tests programmatically.
+
+1. **Install the Specmatic Python library**: Use pip, a package installer for Python, to install the Specmatic library.
+
+   ```bash
+   pip install specmatic
+   ```
+
+2. **Run Tests with a Stub**: If you want to run the tests with a stub, you can do so like this:
+
+   ```python
+   import os
+   from specmatic.core.specmatic import Specmatic
+   from your_project import app
+   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+   stub_host = "127.0.0.1"
+   stub_port = 5000
+
+   Specmatic() \
+       .with_project_root(PROJECT_ROOT_DIR) \
+       .with_stub(stub_host, stub_port, [expectation_json_file]) \
+       .with_wsgi_app(app) \
+       .test(TestContract) \
+       .run()
+   ```
+
+   In this example, we are passing an instance of wsgi app like flask. `stub_host`, `stub_port`, and `expectation_json_file` are the the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively. Replace `app` with your Flask application object.¸
+{% endtab %} -->
 
 ## Transient expectations (a.k.a. transient stubs)
 

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -531,52 +531,25 @@ If your tests are written in Python, you can start and stop the stub server with
    from specmatic.core.specmatic import Specmatic
    from your_project import app
    PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+   app_host = "127.0.0.1"
+   app_port = 5000
    stub_host = "127.0.0.1"
    stub_port = 5000
+   expectation_json_file = PROJECT_ROOT_DIR + '/test/data/expectation.json'
 
    Specmatic() \
        .with_project_root(PROJECT_ROOT_DIR) \
        .with_stub(stub_host, stub_port, [expectation_json_file]) \
-       .with_wsgi_app(app) \
+       .with_wsgi_app(app, app_host, app_port) \
        .test(TestContract) \
        .run()
    ```
 
-   In this example, we are passing an instance of wsgi app like flask. `stub_host`, `stub_port`, and `expectation_json_file` are the the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively. Replace `app` with your Flask application object.¸
+   In this example, we are passing an instance of wsgi app like flask. `stub_host`, `stub_port`, and `expectation_json_file` are the the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively. Replace `app` with your Flask application object.
+
+   Here are complete example of [Specmatic stub server](https://github.com/znsio/specmatic-order-bff-python/blob/main/test/test_contract.py) usage in Python.
 {% endtab %}
 {% endtabs %}
-
-<!-- 
-{% tab virtualization python %}
-
-If your tests are written in Python, you can start and stop the stub server within your tests programmatically.
-
-1. **Install the Specmatic Python library**: Use pip, a package installer for Python, to install the Specmatic library.
-
-   ```bash
-   pip install specmatic
-   ```
-
-2. **Run Tests with a Stub**: If you want to run the tests with a stub, you can do so like this:
-
-   ```python
-   import os
-   from specmatic.core.specmatic import Specmatic
-   from your_project import app
-   PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-   stub_host = "127.0.0.1"
-   stub_port = 5000
-
-   Specmatic() \
-       .with_project_root(PROJECT_ROOT_DIR) \
-       .with_stub(stub_host, stub_port, [expectation_json_file]) \
-       .with_wsgi_app(app) \
-       .test(TestContract) \
-       .run()
-   ```
-
-   In this example, we are passing an instance of wsgi app like flask. `stub_host`, `stub_port`, and `expectation_json_file` are the the host and port for the stub server, and the path to a JSON file containing expectations for the stub, respectively. Replace `app` with your Flask application object.¸
-{% endtab %} -->
 
 ## Transient expectations (a.k.a. transient stubs)
 


### PR DESCRIPTION
- Added Python tab to show `Programmatically Executing Specmatic Contract As Tests In Python` in `Contract Tests` section of documentation. 
- Added steps to programmatically run stub server in python in the `Service Virtualization` section of documentation.