### PR TITLE
Broken Links Fixed On Specmatic Documentation

### DIFF
--- a/_includes/setup_command_line.md
+++ b/_includes/setup_command_line.md
@@ -1,6 +1,6 @@
 Specmatic can be used as a standalone executable and also included [programmatically](https://specmatic.in/documentation/service_virtualization_tutorial.html#programmatically-starting-stub-server-within-tests) as part of your test suite.
 
-For getting started quickly, let us use Specmatic standalone execuable within our command line.
+For getting started quickly, let us use Specmatic standalone executable within our command line.
 
 The Specmatic standalone executable is accessible through various prominent distribution channels.
 
@@ -64,7 +64,7 @@ Please follow these steps to do so:
 ---
 ### Tip to run java jar easily
 
-By following below tip running `java -jar specmatic.jar` everytime can be avoided
+By following below tip running `java -jar specmatic.jar` every time can be avoided
 
 {% tabs hint-java %}
 {% tab hint-java mac/linux %}

--- a/documentation/authentication-by-reaching-another-service.md
+++ b/documentation/authentication-by-reaching-another-service.md
@@ -120,7 +120,7 @@ In `($auth.token)`, `auth` is the `value` that we declared above, and `token` is
 ## 3. Run the contract tests
 
 ### Declare the application contract in specmatic.json
-Make sure to declare the contract you're running as a test in [specmatic.json](documentation/../specmatic_json.md). Take a look at [specmatic.json in the petstore sample project](https://github.com/znsio/petstore/blob/master/specmatic.json) for an example of this. You can read more about [running contract tests using Specmatic here](documentation/../contract_tests.html).
+Make sure to declare the contract you're running as a test in [specmatic.json](documentation/../specmatic_json.html). Take a look at [specmatic.json in the petstore sample project](https://github.com/znsio/petstore/blob/master/specmatic.json) for an example of this. You can read more about [running contract tests using Specmatic here](documentation/../contract_tests.html).
 
 ### Execute the tests
 Finally, run the tests. You must specify the environment while doing so, for Specmatic to pick up the variables and baseurls relevant to that environment.

--- a/documentation/continuous_integration.md
+++ b/documentation/continuous_integration.md
@@ -7,7 +7,7 @@ nav_order: 31
 Contract Tests
 ==============
 
-Specmatic is a platform and programming language independent execuable. We can run it in all CI environments through [command line](http://localhost:4000/getting_started.html#setup).
+Specmatic is a platform and programming language independent execuable. We can run it in all CI environments through [command line](/documentation/getting_started.html#setup).
 
 ## Featured utilities
 

--- a/documentation/language.md
+++ b/documentation/language.md
@@ -641,7 +641,7 @@ Then status 200
 
 ### XML Data Types
 
-You can use all the scalar data types described [earlier in this document](built-in-data-types) except for null.
+You can use all the scalar data types described [earlier in this document](#built-in-data-types) except for null.
 
 ### XML Attributes
 

--- a/documentation/service_virtualisation.md
+++ b/documentation/service_virtualisation.md
@@ -28,7 +28,7 @@ Service Virtualisation
     - [Forward Unstubbed Requests To An Actual Service](#forward-unstubbed-requests-to-an-actual-service)
     - [Stub file format](#stub-file-format)
 
-[Read here about contract testing and where Specmatic fits in](/contract_testing.html).
+[Read here about contract testing and where Specmatic fits in](/documentation/contract_tests.html).
 
 ### Why Service Virtualisation
 


### PR DESCRIPTION
- [x] Fixed CI Sections Command Line Text Link
- [x] Fixed Link on Authentication by reaching another service page
- [x] Fixed Data Type Section Link On Language Page
- [x] Fixed typos
- [x] Fixed Broken Link On the Service Virtualization Page