### PR TITLE
Broken Link Fixes

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -48,5 +48,3 @@ Systems interact with each other through several means. Specmatic hopes to addre
 * Versioning
 * Support for **SOAP/XML**, **Kafka**, **callbacks** and more
 * Already have a lot of APIs? Don't worry, we can take your **Postman Collection** and easily generate contracts from it
-
-[**Read more about them here**](/Features.html)

--- a/documentation/authoring_contracts.md
+++ b/documentation/authoring_contracts.md
@@ -60,7 +60,7 @@ If you know what the request and response should look like, you can start by cre
 
 ### Create the sample file
 
-The file must contain a single json object using the [Specmatic stub file format](service_virtualisation.html#stub-file-format).
+The file must contain a single JSON object using the [Specmatic stub file format](/documentation/test_data_format.html).
 
 Here's a sample file that contains a request for the name of a customer by id:
 

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -210,7 +210,7 @@ Thus, the request and response examples named `FETCH_EMPLOYEE_SUCCESS` taken tog
 
 Note that the response example named `FETCH_EMPLOYEE_SUCCESS` is not compared with values returned by the application. This is what sets a Contract Test apart from an API Test. A Contract Test is concerned with checking the APIs signature, while API tests are concerned wtih checking the APIs logic.
 
-However the response example named `FETCH_EMPLOYEE_SUCCESS` is verified and used in [service virtualisation](/documentation/service_virtualisation.html#examples-as-expectations).
+However the response example named `FETCH_EMPLOYEE_SUCCESS` is verified and used in [service virtualization](/documentation/service_virtualization_tutorial.html#examples-as-expectations).
 
 ### Externalising examples / test cases
 


### PR DESCRIPTION
- Fixed service virtualization example link on the `Contract Tests` page.
- Removed the `Features` page link from the `Documentation Home` as the `Features` page is archived.
- Fixed Specmatic stub file format link on the `Generating API Specifications` page.