### PR TITLE
Refactored the Way Version ENV Is Extracted and Used

### DIFF
--- a/.github/workflows/update-doc-version.yaml
+++ b/.github/workflows/update-doc-version.yaml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [specmatic-core-release]
 
+env:
+  VERSION: ${{ github.event.client_payload.version }}  
+   
 jobs:
   update_docs:
     runs-on: ubuntu-latest
@@ -18,18 +21,16 @@ jobs:
         ref: main
         token: ${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_TOKEN }}
         path: documentation
+    - name: Set version in environment
+      run: echo "VERSION=${VERSION#refs/tags/}" >> $GITHUB_ENV
     - name: Update version in _config.yaml
       run: |
-        version=${{ github.event.client_payload.version }}
-        version=${version#refs/tags/}
-        sed -i "s/latest_release: .*/latest_release: $version/" documentation/_config.yaml
+        sed -i "s/latest_release: .*/latest_release: $VERSION/" documentation/_config.yaml
     - name: Commit and push    
       run: |
-        version=${{ github.event.client_payload.version }}
-        version=${version#refs/tags/}
         git config --global user.name '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_NAME }}'
         git config --global user.email '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_EMAIL }}'
         git add .
-        git commit -m "Updated Specmatic Documnentation Version To $version"
+        git commit -m "Updated Specmatic Documnentation Version To $VERSION"
         git push
       working-directory: documentation

--- a/.github/workflows/update-doc-version.yaml
+++ b/.github/workflows/update-doc-version.yaml
@@ -5,7 +5,7 @@ on:
     types: [specmatic-core-release]
 
 env:
-  VERSION: ${{ github.event.client_payload.version }}  
+  SPECMATIC_LATEST_RELEASE_VERSION: ${{ github.event.client_payload.latest-release }}    
    
 jobs:
   update_docs:
@@ -21,16 +21,14 @@ jobs:
         ref: main
         token: ${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_TOKEN }}
         path: documentation
-    - name: Set version in environment
-      run: echo "VERSION=${VERSION#refs/tags/}" >> $GITHUB_ENV
     - name: Update version in _config.yaml
       run: |
-        sed -i "s/latest_release: .*/latest_release: $VERSION/" documentation/_config.yaml
+        sed -i "s/latest_release: .*/latest_release: $SPECMATIC_LATEST_RELEASE_VERSION/" documentation/_config.yaml
     - name: Commit and push    
       run: |
         git config --global user.name '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_NAME }}'
         git config --global user.email '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_EMAIL }}'
         git add .
-        git commit -m "Updated Specmatic Documnentation Version To $VERSION"
+        git commit -m "Updated Specmatic Documnentation Version To $SPECMATIC_LATEST_RELEASE_VERSION"
         git push
       working-directory: documentation

--- a/.github/workflows/update-doc-version.yaml
+++ b/.github/workflows/update-doc-version.yaml
@@ -29,6 +29,6 @@ jobs:
         git config --global user.name '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_NAME }}'
         git config --global user.email '${{ secrets.SPECMATIC_CORE_VERSION_UPDATE_USER_EMAIL }}'
         git add .
-        git commit -m "Updated Specmatic Documnentation Version To $SPECMATIC_LATEST_RELEASE_VERSION"
+        git commit -m "Updated Specmatic Documentation Version To $SPECMATIC_LATEST_RELEASE_VERSION"
         git push
       working-directory: documentation


### PR DESCRIPTION
- Added an environment variable at the workflow level to store the version.
- Introduced a new step to set the version in the environment, removing the `refs/tags/` prefix.
- Updated the steps to use the environment variable, eliminating the need to extract the version twice.