### PR TITLE
Remove beta tags, note availability in paid plans, and link to pricing page.

### DIFF
--- a/documentation/stubbing-jms.md
+++ b/documentation/stubbing-jms.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: JMS Stubbing (Private Beta)
+title: JMS Stubbing
 parent: Documentation
 nav_exclude: true
 ---
 
-# JMS Stubbing (Private Beta)
+# JMS Stubbing
 
-> The `specmatic-jms` module described in this document is currently in private beta. Please get in touch with us through the `Contact Us` form at https://specmatic.in if you'd like to try it out.
+> The `specmatic-jms` module described in this document is available in the [Pro plan](https://specmatic.io/pricing/) or higher. Please get in touch with us through the `Contact Us` form at [specmatic.io](https://specmatic.io) if you'd like to try it out.
 
 ## Introduction
 

--- a/documentation/stubbing-kafka.md
+++ b/documentation/stubbing-kafka.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Kafka Stubbing (Private Beta)
+title: Kafka Stubbing
 parent: Documentation
 nav_exclude: true
 ---
 
-# Kafka Stubbing (Private Beta)
+# Kafka Stubbing
 
-> The `specmatic-kafka` module described in this document is currently in private beta. Please get in touch with us through the `Contact Us` form at https://specmatic.in if you'd like to try it out.
+> The `specmatic-kafka` module described in this document is available in the [Pro plan](https://specmatic.io/pricing/) or higher. Please get in touch with us through the `Contact Us` form at [specmatic.io](https://specmatic.io) if you'd like to try it out.
 
 ## Introduction to Kafka stubbing
 

--- a/documentation/stubbing-redis.md
+++ b/documentation/stubbing-redis.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Redis Stubbing (Private Beta)
+title: Redis Stubbing
 parent: Documentation
 nav_exclude: true
 ---
 
-# Redis Stubbing (Private Beta)
+# Redis Stubbing
 
-> The `specmatic-redis` module described in this document is currently in private beta. Please get in touch with us through the `Contact Us` form at https://specmatic.in if you'd like to try it out.
+> The `specmatic-redis` module described in this document is available in the [Pro plan](https://specmatic.io/pricing/) or higher. Please get in touch with us through the `Contact Us` form at [specmatic.io](https://specmatic.io) if you'd like to try it out.
 
 ## Introduction to Redis Stubbing
 

--- a/documentation/stubbing_database.md
+++ b/documentation/stubbing_database.md
@@ -1,13 +1,13 @@
 ---
 layout: default
-title: Database Stubbing (Private Beta)
+title: Database Stubbing
 parent: Documentation
 nav_exclude: true
 ---
 
-# Database Stubbing (Private Beta)
+# Database Stubbing
 
-> The `database-mock` module described in this document is currently in private beta. Please get in touch with us through the `Contact Us` form at https://specmatic.in if you'd like to try it out.
+> The `database-mock` module described in this document is available in the [Pro plan](https://specmatic.io/pricing/) or higher. Please get in touch with us through the `Contact Us` form at [specmatic.io](https://specmatic.io) if you'd like to try it out.
 
 ## Introduction to Database Stubbing
 


### PR DESCRIPTION
Removed beta tags, noted availability in paid plans, and linked to pricing page for:
1. Database Stubbing
2. Kafka Stubbing
3. JMS Stubbing
4. Redis Stubbing