### PR TITLE
Added configuration file pickup priority in documentation

### DIFF
--- a/_includes/specmatic_config.md
+++ b/_includes/specmatic_config.md
@@ -563,6 +563,9 @@ Each environment configuration can contain
 - `baseurls` - needed when running contracts as test as part of [authentication](documentation/../authentication.html)
 - `variables` - these values are plugged into the Examples rows of an auth contract for [authentication](documentation/../authentication.html), or even when running regular contract tests
 
+First, we check the CONFIG_FILE_PATH environment variable for the configuration file. If it is not present, we check the path provided through the --config parameter. If not found, we finally look in the current root directory.
+
+
 ### Hooks
 
 A hook is simply a command that can run on the Terminal or Command Prompt.


### PR DESCRIPTION
Configuration file pickup priority in documentation
1st priority goes to environment variable CONFIG_FILE_PATH for picking configuration file (if not exist)
2nd priority goes to path provided by --config parameter (if not exist)
3rd priority goes to root directory