### PR TITLE
Filter Operations Enhancements (Syntax Upgradation)

### DIFF
--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -957,7 +957,7 @@ specmatic test --filter="METHOD='POST' && PATH='/users'"
 
 #### Excluding Tests
 
-Use `--filter` negate comparison (`!=`) to exclude tests matching specific criteria:
+Here's how you can provide filter criteria to exclude tests:
 
 ```bash
 --filter="STATUS!='400,401' && METHOD!='DELETE'"
@@ -986,44 +986,45 @@ specmatic test --filter="STATUS='2xx'"
 
 2. Skip authentication error tests:
 ```bash
-# Skips all 400-level status codes
 specmatic test --filter!="STATUS='4xx'"  
+```
 
-# Or more specifically:
+3. Skip specific status codes:
+```bash
 specmatic test --filter!="STATUS='401,403'"
 ```
 
-3. Test specific API endpoints:
+4. Test specific API endpoints:
 ```bash
 specmatic test --filter="PATH='/users,/products'"
 ```
-4. Test API endpoints with wildcard(`*`) for `PATH`:
-```bash
-# Matches all paths that begin with /users/ followed by any pattern.
-specmatic test --filter="PATH='/users/*'"
 
-# Matches all paths that begin with /products/, followed by any pattern, and end with /v1.
+5. Test API endpoints with wildcard(`*`) for `PATH`:
+```bash
+specmatic test --filter="PATH='/users/*'"
+```
+
+6. Test all paths that begin with /products/, followed by any pattern, and end with /v1.
+```bash
 specmatic test --filter="PATH='/products/*/v1'"
 ```
-5. Combine multiple filters:
+
+7. Combine multiple filters:
 ```bash
 specmatic test --filter="(PATH='/users' && METHOD='POST') || (PATH='/products' && METHOD='POST')"
 ```
-6. Exclude specified filters:
+
+8. Exclude specified filters:
 ```bash
 specmatic test --filter="!(PATH='/users' && METHOD='POST') && !(PATH='/products' && METHOD='POST')"
 ```
 
-### Real-world Scenario
+### Putting it all together
 
-For an OpenAPI spec with an endpoint `/api/employees`, you might run:
+Let's say you want to run tests for the employee creation API (`POST /employees`), the API to fetch department details (`GET /department`), while skipping any 4xx and 500 status tests:
 
 ```bash
-# Run only employee creation tests
-specmatic test --filter="PATH='/api/employees' && METHOD='POST'"
-
-# Skip all error scenarios
-specmatic test --filter="STATUS!='4xx,500'"  # Skip all client and server errors
+specmatic test --filter="((PATH='/employees' && METHOD='POST') || (PATH='/department' && METHOD='GET')) && STATUS!='4xx,500'"
 ```
 
 ### Additional Tips

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -1026,35 +1026,15 @@ specmatic test --filter="PATH='/api/employees' && METHOD='POST'"
 specmatic test --filter="STATUS!='4xx,500'"  # Skip all client and server errors
 ```
 
-## Legacy Filter Options (Deprecated)
-
-> **Note:** The following options are deprecated and will be removed in a future version. We recommend using the new filter system described above.
-
-- `--filter-name`: Run tests matching a specific name
-- `--filter-not-name`: Exclude tests matching a specific name
-
-Basic usage of deprecated options:
-```bash
-specmatic test --filter-name "CREATE_EMPLOYEE_SUCCESS"
-specmatic test --filter-not-name "ERROR_SCENARIOS"
-```
-
-To migrate from legacy filters to the new system, use these equivalents:
-
-```bash
-# Old way
---filter-name "POST /api/employees"
-
-# New way
---filter="METHOD=POST" --filter="PATH=/api/employees"
-```
-
 ### Additional Tips
 
-- Filters are case-sensitive
-- When multiple filters are specified, tests must match ALL criteria (AND operation)
-- Within a single filter with multiple values, tests matching ANY value will be included (OR operation)
-
+- Filters are case-sensitive.
+- Use **single parentheses** to separate values from keys within a filter.
+- When multiple filters are specified, tests must match **ALL** criteria (**AND** operation).
+- Within a single filter with multiple values, tests matching **ANY** value will be included (**OR** operation).
+- **Negation(!)** causes a block to be excluded from being considered.
+- **Wildcard(*)** can only be used with **PATH**.
+- **Range (2xx, 50x)** can only be used with **STATUS**.
 ---
 
 ### API Coverage

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -912,10 +912,10 @@ Specmatic provides powerful filtering capabilities to help you run specific test
 
 ### Using the New Filter System (Recommended)
 
-The `--filter` and `--filter-not` options provide granular control over which tests to run:
+The `--filter` option provides granular control over which tests to run:
 
 ```bash
-specmatic test --filter="METHOD=POST" --filter="PATH=/users"
+specmatic test --filter="METHOD='POST' && PATH='/users'"
 ```
 
 #### Available Filter Keys
@@ -927,29 +927,40 @@ specmatic test --filter="METHOD=POST" --filter="PATH=/users"
 - `QUERY-PARAM`: Filter by query parameters
 - `EXAMPLE-NAME`: Filter by example names
 
+#### Available Filter Operations 
+- `&&` : Represents a logical AND operator.
+- `||` : Represents a logical OR operator.
+- `!` : Negates the applied condition.
+- `=`, `!=` : Comparison operators for comparing a key with its value.
+- `(`, `)` : Parentheses are used to group multiple filter expressions.
+
 #### Filter Syntax
 
 1. Single value:
 ```bash
---filter="METHOD=GET"
+--filter="METHOD='GET'"
 ```
 
 2. Multiple values for same filter (comma-separated):
 ```bash
---filter="METHOD=GET,POST"
+--filter="METHOD='GET,POST'"
 ```
 
-3. Multiple filters:
+3. Multiple filters can be joined with AND operation (`&&`):
 ```bash
---filter="METHOD=GET,POST" --filter="PATH=/users"
+--filter="METHOD='GET,POST' && PATH='/users'"
+```
+4. Multiple filters Joined with OR Operation (`||`):
+```bash
+--filter="PATH='/users,/products' || STATUS='200'"
 ```
 
 #### Excluding Tests
 
-Use `--filter-not` to exclude tests matching specific criteria:
+Use `--filter` negate comparison (`!=`) to exclude tests matching specific criteria:
 
 ```bash
---filter-not="STATUS=400,401" --filter-not="METHOD=DELETE"
+--filter="STATUS!='400,401' && METHOD!='DELETE'"
 ```
 
 ### Programmatic Usage
@@ -958,10 +969,10 @@ Set environment properties in your test setup:
 
 ```java
 // Include specific tests
-System.setProperty("filter", "METHOD=POST;PATH=/users");
+System.setProperty("filter", "METHOD='POST' && PATH='/users'");
 
 // Exclude tests
-System.setProperty("filterNot", "STATUS=400,401");
+System.setProperty("filter", "STATUS!='400,401'");
 ```
 
 ## Examples
@@ -970,24 +981,28 @@ System.setProperty("filterNot", "STATUS=400,401");
 
 1. Run only successful response tests:
 ```bash
-specmatic test --filter="STATUS=2xx"
+specmatic test --filter="STATUS='2xx'"
 ```
 
 2. Skip authentication error tests:
 ```bash
-specmatic test --filter-not="STATUS=4xx"  # Skips all 400-level status codes
+specmatic test --filter!="STATUS='4xx'"  # Skips all 400-level status codes
 # Or more specifically:
-specmatic test --filter-not="STATUS=401,403"
+specmatic test --filter!="STATUS='401,403'"
 ```
 
 3. Test specific API endpoints:
 ```bash
-specmatic test --filter="PATH=/users,/products"
+specmatic test --filter="PATH='/users,/products'"
 ```
 
 4. Combine multiple filters:
 ```bash
-specmatic test --filter="METHOD=POST" --filter="PATH=/users" --filter-not="STATUS=400"
+specmatic test --filter="(PATH='/users' && METHOD='POST') || (PATH='/products' && METHOD='POST')"
+```
+5. Exclude specified filters:
+```bash
+specmatic test --filter="!(PATH='/users' && METHOD='POST') && !(PATH='/products' && METHOD='POST')"
 ```
 
 ### Real-world Scenario
@@ -996,10 +1011,10 @@ For an OpenAPI spec with an endpoint `/api/employees`, you might run:
 
 ```bash
 # Run only employee creation tests
-specmatic test --filter="PATH=/api/employees" --filter="METHOD=POST"
+specmatic test --filter="PATH='/api/employees' && METHOD='POST'"
 
 # Skip all error scenarios
-specmatic test --filter-not="STATUS=4xx,500"  # Skip all client and server errors
+specmatic test --filter="STATUS!='4xx,500'"  # Skip all client and server errors
 ```
 
 ## Legacy Filter Options (Deprecated)

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -986,7 +986,9 @@ specmatic test --filter="STATUS='2xx'"
 
 2. Skip authentication error tests:
 ```bash
-specmatic test --filter!="STATUS='4xx'"  # Skips all 400-level status codes
+# Skips all 400-level status codes
+specmatic test --filter!="STATUS='4xx'"  
+
 # Or more specifically:
 specmatic test --filter!="STATUS='401,403'"
 ```
@@ -995,12 +997,19 @@ specmatic test --filter!="STATUS='401,403'"
 ```bash
 specmatic test --filter="PATH='/users,/products'"
 ```
+4. Test API endpoints with wildcard(`*`) for `PATH`:
+```bash
+# Matches all paths that begin with /users/ followed by any pattern.
+specmatic test --filter="PATH='/users/*'"
 
-4. Combine multiple filters:
+# Matches all paths that begin with /products/, followed by any pattern, and end with /v1.
+specmatic test --filter="PATH='/products/*/v1'"
+```
+5. Combine multiple filters:
 ```bash
 specmatic test --filter="(PATH='/users' && METHOD='POST') || (PATH='/products' && METHOD='POST')"
 ```
-5. Exclude specified filters:
+6. Exclude specified filters:
 ```bash
 specmatic test --filter="!(PATH='/users' && METHOD='POST') && !(PATH='/products' && METHOD='POST')"
 ```


### PR DESCRIPTION
This PR contains Specmatic new filter upgraded syntax : 


- The filter handling conditions are improved using equality (=) and inequality (!=) operators
```sh
--filter "METHOD!='GET' || PATH!='/users'"

```
-  Supports multiple values separated by commas.
```sh
--filter "PATH='/products,/hub' && METHOD='GET,POST' && STATUS='200,400'"
--filter "STATUS!='202,401,403'"
--filter "(PATH='/monitor/(id:string)' || (METHOD='GET,POST' && STATUS=200))"
```
- Path Matching: The filter supports wildcard path matching using asterisks (*).
```sh
--filter "PATH='/products/*/1'"
```
- Range Matching: The filter can evaluate status codes within specified ranges, such as "2xx" or "20x".
```sh
--filter "STATUS='2xx'"
```

Filter commands can be used in the following places -

**Example Interactive Server**:

```sh
specmatic examples interactive --contract-file openapi.yaml --filter "STATUS!=202 && PATH!='/hub,/hub/(id:string)'"
```

**Specmatic Tests**:
```sh
specmatic test --filter "STATUS!=202 && PATH!='/hub,/hub/(id:string)'"
```
