### PR TITLE
Updated the versions in the workflow that publishes the website

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The latest [action](https://github.com/znsio/specmatic-documentation/actions/runs/13071960223/job/36475378625) that ran to publish the website failed.

The error links to this [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) which says that our workflow is using deprecated version `3` of `upload-artifact`.

`jekyll.yaml` doesn't use that action directly. However we do use other actions that may be using it.

This PR upgrades the relevant versions based on the documentation of the [upload-pages-artifact](https://github.com/actions/upload-pages-artifact) action.