### PR TITLE
Update Configuration page: Break nesting of tab

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuration
 parent: Documentation
-nav_order: 14.1
+nav_order: 14
 ---
 
 <span style="color:gray;">Update Date:  14/02/2025</span>

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -2,9 +2,10 @@
 layout: default
 title: Configuration
 parent: Documentation
-nav_order: 14
-has_children: true
+nav_order: 14.1
 ---
+
+<span style="color:gray;">Update Date:  14/02/2025</span>
 
 Configuration
 =============

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -30,7 +30,7 @@ Configuration
     - [Hooks](#hooks)
 
 
-Version 2 is the latest as of 14/02/2025. If you are looking for an older version of the configs, refer to [older configuration versions](/documentation/older_configuration_versions.html) page.
+Note: Version 2 is the latest as of 14/02/2025. If you are looking for an older version of the configs, refer to [older configuration versions](/documentation/older_configuration_versions.html) page.
 
 ### Getting started
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -29,6 +29,9 @@ Configuration
     - [Declare environment configuration](#declare-environment-configuration)
     - [Hooks](#hooks)
 
+
+Version 2 is the latest as of 14/02/2025. If you are looking for an older version of the configs, refer to [older configuration versions](/documentation/older_configuration_versions.html) page.
+
 ### Getting started
 
 We often have to pass more than one API Specification file to Specmatic to stub or test. While it is possible to send all the files as command line options, there is a better way.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -340,6 +340,7 @@ Specmatic can generate reports based on the below configuration:
 {% tabs report_configuration %}
 {% tab report_configuration specmatic.yaml %}
 ```yaml
+version: 2
 report:
   formatters:
     - type: text
@@ -357,6 +358,7 @@ report:
 {% endtab %}
 {% tab report_configuration specmatic.json %}
 ```json
+"version": 2,
 "report": {
     "formatters": [
       {
@@ -521,6 +523,7 @@ Contains details of the project pipeline.
 {% tabs pipeline_configuration %}
 {% tab pipeline_configuration specmatic.yaml %}
 ```yaml
+version: 2
 auth:
   bearer-file: ./central_repo_auth_token.txt
 
@@ -534,6 +537,7 @@ pipeline:
 {% tab pipeline_configuration specmatic.json %}
 ```json
 {
+  "version": 2,
   "auth": {
     "bearer-file": "./central_repo_auth_token.txt"
   },
@@ -574,6 +578,7 @@ You can read more about `System.AccessToken` [here](https://docs.microsoft.com/e
 {% tabs environment_configuration %}
 {% tab environment_configuration specmatic.yaml %}
 ```yaml
+version: 2
 environments:
   staging:
     baseurls:
@@ -585,6 +590,7 @@ environments:
 {% endtab %}
 {% tab environment_configuration specmatic.json %}
 ```json
+  "version": 2,
   "environments": {
     "staging": {
       "baseurls": {
@@ -615,6 +621,7 @@ A hook is simply a command that can run on the Terminal or Command Prompt.
 {% tabs hooks_configuration %}
 {% tab hooks_configuration specmatic.yaml %}
 ```yaml
+version: 2
 hooks:
   stub_load_contract: python load.py
 ```
@@ -622,6 +629,7 @@ hooks:
 {% tab hooks_configuration specmatic.json %}
 ```json
 {
+  "version": 2,
   "hooks": {
     "stub_load_contract": "python load.py"
   }

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -1078,17 +1078,23 @@ specmatic test --filter="((PATH='/employees' && METHOD='POST') || (PATH='/depart
 ---
 ### API Coverage
 
-After running the tests, Specmatic will print out a tabular report showing which APIs were covered by the tests.
+After executing the tests, Specmatic generates a tabular report that displays which APIs were covered by the tests. It can also retrieve the APIs exposed by the application through the actuator module to identify which APIs were *not* covered by contract tests or those that are not *implemented* in the service.
 
-In addition, it can read the APIs exposed by the application from the actuator module, to indicate in the same report which APIs were not covered by contract tests.
+There are two methods to enable this feature:
 
-To get this working:
-1. Turn on the actuator module, and enable the mappings endpoint. You can read more about this online.
-2. Set the system property `endpointsAPI` to the mappings endpoint exposed by actuator.
+#### 1. Enable the Actuator Mapping Endpoint
 
-Look at the sample project below to see this in action. Observe the system property, set in the [ContractTest](https://github.com/znsio/specmatic-order-api-java/blob/main/src/test/java/com/store/ContractTest.java) class, and the actuator-related dependency added in `pom.xml`.
+Activate the actuator mapping endpoint in your backend framework. Specify the URL of this endpoint as a system property using `endpointsAPI`. Specmatic will use this endpoint to retrieve and analyze the available paths and methods exposed by your backend server.
 
-The data in the coverage report is written to a file at `build/reports/specmatic/coverage_report.json`, relative to the directory from which Specmatic was executed.
+Refer to the sample project below to observe this in action. Pay attention to the system property set in the [ContractTest](https://github.com/znsio/specmatic-order-api-java/blob/main/src/test/java/com/store/ContractTest.java) class, as well as the actuator-related dependency included in `pom.xml`.
+
+#### 2. Use Swagger UI
+
+Various programming languages and frameworks offer support for Swagger UI. For example, in .NET, Swashbuckle automatically generates an OpenAPI specification from controllers and models, making it easier to document, visualize, and interact with APIs directly from a web interface.
+
+Specmatic will automatically detect and utilize Swagger UI if it is available. By default, Specmatic sends a request to `/swagger/v1/swagger.yaml`. You can customize the base URL for Swagger UI by configuring the `SWAGGER_UI_BASEURL` system property. If this property is not defined, Specmatic will default to using the URL of the System Under Test (SUT) as the base URL.
+
+The data from the coverage report is saved to a file located at `build/reports/specmatic/coverage_report.json`, relative to the directory from which Specmatic was executed. It is also accessible in the HTML report generated at `build/reports/specmatic/html/index.html`.
 
 ---
 

--- a/documentation/contract_tests.md
+++ b/documentation/contract_tests.md
@@ -58,15 +58,15 @@ Contract Tests
     - [Real-World Scenarios](#real-world-scenarios)
     - [API Gateway Transformations](#api-gateway-transformations)
     - [Implementation Example](#implementation-example)
-      - [**Initial Client API Specification**](#initial-client-api-specification)
-      - [**Setting Up Test Hooks**](#setting-up-test-hooks)
+      - [Initial Client API Specification](#initial-client-api-specification)
+    - [Setting Up Test Hooks](#setting-up-test-hooks)
     - [Sample Project Access](#sample-project-access)
       - [Creating the JAR File](#creating-the-jar-file)
     - [How It Works](#how-it-works)
     - [Conclusion](#conclusion-1)
-    - [Advanced Features](#advanced-features)
-      - [Generative Tests](#generative-tests)
-      - [Limiting the Count of Tests](#limiting-the-count-of-tests)
+  - [Advanced Features](#advanced-features)
+    - [Generative Tests](#generative-tests)
+    - [Limiting the Count of Tests](#limiting-the-count-of-tests)
     - [Sample Project](#sample-project)
 
 ### Overview
@@ -1331,7 +1331,7 @@ Without test hooks, Specmatic tests would fail because:
 
 ### Implementation Example
 
-#### **Initial Client API Specification**
+#### Initial Client API Specification
 <br>
 Here's a typical client-side API specification:
 
@@ -1373,9 +1373,9 @@ paths:
                     sku:
                       type: string
 ```
-<br>
-#### **Setting Up Test Hooks**
-<br>
+
+### Setting Up Test Hooks
+
 Step 1: **Create specmatic.yaml configuration file:**
 
 {% tabs config %}
@@ -1542,9 +1542,9 @@ Test hooks provide a powerful way to bridge the gap between client specification
 
 ---
 
-### Advanced Features
+## Advanced Features
 
-#### Generative Tests
+### Generative Tests
 
 Contract testing within the bounds of the contract is not enough. HTTP prescribes what should happen when contract-invalid requests are sent. To ensure that the application operates as required by HTTP, we need to test it with contract-invalid requests.
 
@@ -1630,7 +1630,7 @@ System.setProperty("SPECMATIC_GENERATIVE_TESTS", "true")
 
 The best way to see it in action is to try it out with one of your micro-services and it's API specifications.
 
-#### Limiting the Count of Tests
+### Limiting the Count of Tests
 
 Where there are no examples, Specmatic generates tests from the contract. And if there are too many optional headers, query parameters, JSON keys, nullables, and so on, Specmatic may generate too many tests.
 

--- a/documentation/older_configuration_versions.md
+++ b/documentation/older_configuration_versions.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Older Configuration Versions
-parent: Configuration
-nav_order: 1
+parent: Documentation
+nav_order: 14.2
 has_children: true
 ---
 

--- a/documentation/older_configuration_versions.md
+++ b/documentation/older_configuration_versions.md
@@ -1,12 +1,9 @@
 ---
 layout: default
 title: Older Configuration Versions
-parent: Documentation
-nav_order: 14.2
-has_children: true
 ---
 
-Configuration
+Older Configuration Versions
 =============
 
 These versions are supported, but we recommended that you update to the latest to benefit from the newest features.


### PR DESCRIPTION
- Move "Older Configuration Versions" tab to top level.
- Add "Update Date" on Configuration page