### PR TITLE
Update docker instructions

### DIFF
--- a/_includes/setup_command_line.md
+++ b/_includes/setup_command_line.md
@@ -21,13 +21,13 @@ java -jar specmatic.jar
 {% endtab %}
 {% tab install npm %}
 
-Install specmatic npm package globally 
+Install specmatic npm package globally
 
 ``` bash
 npm install -g specmatic
 ```
 
-Or you can run specmatic without installing it as below 
+Or you can run specmatic without installing it as below
 
 ``` bash
 npx specmatic
@@ -36,27 +36,11 @@ npx specmatic
 
 {% tab install docker %}
 
-Docker Pull Command for specmatic docker image
-
-``` bash
-docker pull znsio/specmatic
-```
-
 Run specmatic by
 
 ``` bash
 docker run znsio/specmatic
 ```
-
-**Important**: If you're using a machine with an Apple Silicon chip, you'll need to enable Rosetta for accelerated x86/amd64 binary emulation.
-
-Please follow these steps to do so:
-
-1. Update your Docker Desktop application to the latest version.
-2. Navigate to 'Settings', then 'General Settings'.
-3. Ensure the `Use Rosetta for x86/amd64 emulation on Apple Silicon` option is checked.
-4. Save your settings and restart Docker Desktop for the changes to take effect.
-
 
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
* Remove unnecessary `docker pull`, docker run will always do the pull
* Remove note on Apple silicon since we publish amd64 and arm64 images
